### PR TITLE
Make actual videos to make gifs from, keep actual videos

### DIFF
--- a/lib/lolcommits/capturer/capture_linux_animated.rb
+++ b/lib/lolcommits/capturer/capture_linux_animated.rb
@@ -6,24 +6,7 @@ module Lolcommits
       FileUtils.mkdir_p(frames_location)
 
       # capture the raw video with ffmpeg video4linux2
-      system_call "ffmpeg -v quiet -y -f video4linux2 -video_size 320x240 -i #{capture_device_string} -t #{capture_duration} \"#{video_location}\" > /dev/null"
-      return unless File.exist?(video_location)
-
-      # convert raw video to png frames with ffmpeg
-      system_call "ffmpeg #{capture_delay_string} -v quiet -i \"#{video_location}\" -t #{animated_duration} \"#{frames_location}/%09d.png\" > /dev/null"
-
-      # use fps to set delay and number of frames to skip (for lower filesized gifs)
-      fps   = video_fps(video_location)
-      skip  = frame_skip(fps)
-      delay = frame_delay(fps, skip)
-      debug "Capturer: anaimated gif choosing every #{skip} frames with a frame delay of #{delay} (video fps: #{fps})"
-
-      # create the looping animated gif from frames (picks nth frame with seq,
-      # quotes output and concats to a single line with tr)
-      seq_command = "seq -f \"\\\"#{frames_location}/%09g.png\\\"\" 1 #{skip} #{Dir["#{frames_location}/*"].length} | tr '\\n' ' '"
-      seq_frame_files = system_call(seq_command, true)
-      # convert to animated gif with delay and gif optimisation
-      system_call "convert -layers OptimizeTransparency -delay #{delay} -loop 0 #{seq_frame_files} -coalesce \"#{snapshot_location}\""
+      system_call "ffmpeg -nostats -v quiet -y -f video4linux2 -video_size 640x480 -i #{capture_device_string} -t #{capture_duration} \"#{video_location}\" > /dev/null"
     end
 
     private
@@ -31,30 +14,6 @@ module Lolcommits
     def system_call(call_str, capture_output = false)
       debug "Capturer: making system call for \n #{call_str}"
       capture_output ? `#{call_str}` : system(call_str)
-    end
-
-    def frame_delay(fps, skip)
-      # calculate frame delay
-      delay = ((100.0 * skip) / fps.to_f).to_i
-      delay < 6 ? 6 : delay # hard limit for IE browsers
-    end
-
-    def video_fps(file)
-      # inspect fps of the captured video file (default to 29.97)
-      fps = system_call("ffmpeg -i \"#{file}\" 2>&1 | sed -n \"s/.*, \\(.*\\) fp.*/\\1/p\"", true)
-      fps.to_i < 1 ? 29.97 : fps.to_f
-    end
-
-    def frame_skip(fps)
-      # of frames to skip depends on movie fps
-      case fps
-      when 0..15
-        2
-      when 16..28
-        3
-      else
-        4
-      end
     end
 
     def capture_device_string

--- a/lib/lolcommits/capturer/capture_mac_animated.rb
+++ b/lib/lolcommits/capturer/capture_mac_animated.rb
@@ -6,25 +6,7 @@ module Lolcommits
       FileUtils.mkdir_p(frames_location)
 
       # capture the raw video with videosnap
-      system_call "#{executable_path} -s 240 #{capture_device_string}#{capture_delay_string}-t #{animated_duration} --no-audio \"#{video_location}\" > /dev/null"
-      return unless File.exist?(video_location)
-
-      # get fps for ffmpeg output stream configuration
-      fps = video_fps(video_location)
-      # convert raw video to png frames with ffmpeg
-      system_call "ffmpeg -v quiet -i \"#{video_location}\" -t #{animated_duration} -r #{fps} \"#{frames_location}/%09d.png\""
-
-      # use fps to set delay and number of frames to skip (for lower filesized gifs)
-      skip  = frame_skip(fps)
-      delay = frame_delay(fps, skip)
-      debug "Capturer: animated gif choosing every #{skip} frames with a frame delay of #{delay} (video fps: #{fps})"
-
-      # create the looping animated gif from frames (picks nth frame with seq,
-      # quotes output and concats to a single line with tr)
-      seq_command = "seq -f \"\\\"#{frames_location}/%09g.png\\\"\" 1 #{skip} #{Dir["#{frames_location}/*"].length} | tr '\\n' ' '"
-      seq_frame_files = system_call(seq_command, true)
-      # convert to animated gif with delay and gif optimisation
-      system_call "convert -layers OptimizeTransparency -delay #{delay} -loop 0 #{seq_frame_files} -coalesce \"#{snapshot_location}\" > /dev/null"
+      system_call "#{executable_path} -p 640x480 #{capture_device_string}#{capture_delay_string}-t #{animated_duration} --no-audio \"#{video_location}\" > /dev/null"
     end
 
     def executable_path
@@ -36,30 +18,6 @@ module Lolcommits
     def system_call(call_str, capture_output = false)
       debug "Capturer: making system call for \n #{call_str}"
       capture_output ? `#{call_str}` : system(call_str)
-    end
-
-    def frame_delay(fps, skip)
-      # calculate frame delay
-      delay = ((100.0 * skip) / fps.to_f).to_i
-      delay < 6 ? 6 : delay # hard limit for IE browsers
-    end
-
-    def video_fps(file)
-      # inspect fps of the captured video file (default to 29.97)
-      fps = system_call("ffmpeg -i \"#{file}\" 2>&1 | sed -n \"s/.*, \\(.*\\) fp.*/\\1/p\"", true)
-      fps.to_i < 1 ? 29.97 : fps.to_f
-    end
-
-    def frame_skip(fps)
-      # of frames to skip depends on movie fps
-      case fps
-      when 0..15
-        2
-      when 16..28
-        3
-      else
-        4
-      end
     end
 
     def capture_device_string

--- a/lib/lolcommits/capturer/capture_windows_animated.rb
+++ b/lib/lolcommits/capturer/capture_windows_animated.rb
@@ -9,28 +9,7 @@ module Lolcommits
       return unless capture_device_string
 
       # capture raw video with ffmpeg dshow
-      system_call "ffmpeg -v quiet -y -f dshow -i video=\"#{capture_device_string}\" -video_size 320x240 -t #{capture_duration} \"#{video_location}\" > NUL"
-
-      return unless File.exist?(video_location)
-
-      # convert raw video to png frames with ffmpeg
-      system_call "ffmpeg #{capture_delay_string} -v quiet -i \"#{video_location}\" -t #{animated_duration} \"#{frames_location}/%09d.png\" > NUL"
-
-      # use fps to set delay and number of frames to skip (for lower filesized gifs)
-      fps   = video_fps(video_location)
-      skip  = frame_skip(fps)
-      delay = frame_delay(fps, skip)
-      debug "Capturer: animated gif choosing every #{skip} frames with a frame delay of #{delay} (video fps: #{fps})"
-
-      # create the looping animated gif from frames (delete frame files except every #{skip} frame)
-      Dir["#{frames_location}/*.png"].each do |frame_filename|
-        basename = File.basename(frame_filename)
-        frame_number = basename.split('.').first.to_i
-        File.delete(frame_filename) if frame_number % skip != 0
-      end
-
-      # convert to animated gif with delay and gif optimisation
-      system_call "convert -layers OptimizeTransparency -delay #{delay} -loop 0 \"#{frames_location}/*.png\" -coalesce \"#{snapshot_location}\""
+      system_call "ffmpeg -v quiet -y -f dshow -i video=\"#{capture_device_string}\" -video_size 640x480 -t #{capture_duration} \"#{video_location}\" > NUL"
     end
 
     private
@@ -67,30 +46,6 @@ module Lolcommits
     def system_call(call_str, capture_output = false)
       debug "Capturer: making system call for \n #{call_str}"
       capture_output ? `#{call_str}` : system(call_str)
-    end
-
-    def frame_delay(fps, skip)
-      # calculate frame delay
-      delay = ((100.0 * skip) / fps.to_f).to_i
-      delay < 6 ? 6 : delay # hard limit for IE browsers
-    end
-
-    def video_fps(file)
-      # inspect fps of the captured video file (default to 29.97)
-      fps = system_call("ffmpeg -i \"#{file}\" 2>&1 | sed -n \"s/.*, \\(.*\\) fp.*/\\1/p\"", true)
-      fps.to_i < 1 ? 29.97 : fps.to_f
-    end
-
-    def frame_skip(fps)
-      # of frames to skip depends on movie fps
-      case fps
-      when 0..15
-        2
-      when 16..28
-        3
-      else
-        4
-      end
     end
 
     def capture_device_string

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -59,7 +59,7 @@ module Lolcommits
     end
 
     def video_loc
-      File.join(loldir, 'tmp_video.mov')
+      File.join(loldir, 'tmp_video.mp4')
     end
 
     def frames_loc

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -50,10 +50,11 @@ module Lolcommits
       if File.exist?(snapshot_loc) || (capture_animated? && File.exist?(video_loc))
 
         # execute post_capture plugins, use to alter the capture
+        resize_snapshot! if File.exist?(snapshot_loc)
+                
         execute_plugins_for(:post_capture)
 
         make_animated_gif if capture_animated?
-        resize_snapshot! if File.exist?(snapshot_loc)
 
         # execute capture_ready plugins, capture is ready for export/sharing
         execute_plugins_for(:capture_ready)

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -4,7 +4,7 @@ module Lolcommits
   class Runner
     attr_accessor :capture_delay, :capture_stealth, :capture_device, :message,
                   :sha, :snapshot_loc, :main_image, :config, :vcs_info,
-                  :capture_animate
+                  :capture_animate, :video_loc, :main_video
 
     def initialize(attributes = {})
       attributes.each do |attr, val|
@@ -47,12 +47,13 @@ module Lolcommits
       run_capture
 
       # check capture succeded, file must exist
-      if File.exist?(snapshot_loc)
-        ## resize snapshot first
-        resize_snapshot!
+      if File.exist?(snapshot_loc) || (capture_animated? && File.exist?(video_loc))
 
         # execute post_capture plugins, use to alter the capture
         execute_plugins_for(:post_capture)
+
+        make_animated_gif if capture_animated?
+        resize_snapshot! if File.exist?(snapshot_loc)
 
         # execute capture_ready plugins, capture is ready for export/sharing
         execute_plugins_for(:capture_ready)
@@ -70,6 +71,8 @@ module Lolcommits
       puts '*** Preserving this moment in history.' unless capture_stealth
       self.snapshot_loc = config.raw_image(image_file_type)
       self.main_image   = config.main_image(sha, image_file_type)
+      self.main_video   = config.main_image(sha, 'mp4')
+      self.video_loc    = config.video_loc
 
       capturer = Platform.capturer_class(capture_animated?).new(
         capture_device: capture_device,
@@ -87,6 +90,58 @@ module Lolcommits
     end
 
     private
+
+    def capture_delay_string
+      " -ss #{capture_delay}" if capture_delay.to_i > 0
+    end
+
+    def frame_delay(fps, skip)
+      # calculate frame delay
+      delay = ((100.0 * skip) / fps.to_f).to_i
+      delay < 6 ? 6 : delay # hard limit for IE browsers
+    end
+
+    def video_fps(file)
+      # inspect fps of the captured video file (default to 29.97)
+      fps = system_call("ffmpeg -nostats -v quiet -i \"#{file}\" 2>&1 | sed -n \"s/.*, \\(.*\\) fp.*/\\1/p\"", true)
+      fps.to_i < 1 ? 29.97 : fps.to_f
+    end
+
+    def frame_skip(fps)
+      # of frames to skip depends on movie fps
+      case fps
+      when 0..15
+        2
+      when 16..28
+        3
+      else
+        4
+      end
+    end
+
+    def make_animated_gif
+      null_string = "/dev/null"
+      if Lolcommits::Platform.platform_windows?
+        null_string = "nul"
+      end
+      system_call "ffmpeg #{capture_delay_string} -nostats -v quiet -i \"#{main_video}\" -t #{capture_animate} \"#{config.frames_loc}/%09d.png\" > #{null_string}"
+
+      # use fps to set delay and number of frames to skip (for lower filesized gifs)
+      fps   = video_fps(main_video)
+      skip  = frame_skip(fps)
+      delay = frame_delay(fps, skip)
+      debug "Capturer: animated gif choosing every #{skip} frames with a frame delay of #{delay} (video fps: #{fps})"
+
+      # create the looping animated gif from frames (delete frame files except every #{skip} frame)
+      Dir["#{config.frames_loc}/*.png"].each do |frame_filename|
+          basename = File.basename(frame_filename)
+          frame_number = basename.split('.').first.to_i
+          File.delete(frame_filename) if frame_number % skip != 0
+      end
+
+      # convert to animated gif with delay and gif optimisation
+      system_call "convert -layers OptimizeTransparency -delay #{delay} -loop 0 \"#{config.frames_loc}/*.png\" -coalesce \"#{snapshot_loc}\""
+    end
 
     def enabled_plugins
       @enabled_plugins ||= config.plugin_manager.enabled_plugins_for(self)
@@ -113,10 +168,16 @@ module Lolcommits
       FileUtils.cp(snapshot_loc, main_image)
     end
 
+    def system_call(call_str, capture_output = false)
+      debug "Capturer: making system call for \n #{call_str}"
+      capture_output ? `#{call_str}` : system(call_str)
+    end
+
+
     def cleanup!
       debug 'Runner: running cleanup'
       # clean up the captured image and any other raw assets
-      FileUtils.rm(snapshot_loc)
+      FileUtils.rm(snapshot_loc) if File.exists?(snapshot_loc)
       FileUtils.rm_f(config.video_loc)
       FileUtils.rm_rf(config.frames_loc)
     end


### PR DESCRIPTION
I did this about a couple of years  ago and recently reworked it against current master.

The purpose is to make videos, not animated gifs. Animated gifs are MASSIVE in comparison to their mp4 equivalent. MP4's are also smoother.

So, we capture videos first, and then all the gif building is the same process on any platform.

110KB MP4 - https://puu.sh/CZfFH/2e61b69797.mp4
2.6MB Animated GIF
![b111fc2fe39](https://user-images.githubusercontent.com/382760/54259520-ff310f80-45a0-11e9-9be5-fff86fff18c7.gif)

There's a change to lolcommits-loltext that coincides with this - https://github.com/lolcommits/lolcommits-loltext/pull/5