### PR TITLE
fix: rubocop cop Layout/IndentHeredoc got renamed to Layout/HeredocIn…

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Gemspec/OrderedDependencies:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: auto_detection, squiggly, active_support, powerpack, unindent
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Exclude:
     - 'lib/lolcommits/backends/installation_git.rb'
 


### PR DESCRIPTION
rubocop renamed `Layout/IndentHeredoc` to `Layout/HeredocIndentation`, which breaks all test pipelines. I just renamed that cop in `.rubocop_todo.yml`. 

---
#### :memo: Checklist

Please check this list and leave it intact for the reviewer. Thanks! :heart:

- [ ] Commit messages provide context (why not just what, some tips [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).
- [ ] If relevant, mention GitHub issue number above and include in a commit message.
- [x] Latest code from master merged.
- [ ] New behaviour has test coverage.
- [ ] Avoid duplicating code.
- [ ] No commented out code.
- [ ] Avoid comments for your code, write code that explains itself.
- [x] Changes are simple, useful, clear and brief.
