### PR TITLE
Support delays w/ Linux animated GIFs

### DIFF
--- a/lib/lolcommits/capturer/capture_linux_video.rb
+++ b/lib/lolcommits/capturer/capture_linux_video.rb
@@ -3,7 +3,7 @@
 module Lolcommits
   class CaptureLinuxVideo < Capturer
     def capture
-      system_call "ffmpeg -nostats -v quiet -y -f video4linux2 -video_size 640x480 -i #{capture_device_string} -t #{capture_duration} \"#{capture_path}\" > /dev/null"
+      system_call "ffmpeg -nostats -v quiet -y -f video4linux2 -video_size 640x480 -i #{capture_device_string} -t #{capture_duration} -ss #{capture_delay || 0} \"#{capture_path}\" > /dev/null"
     end
 
     private


### PR DESCRIPTION
This PR alters the ffmpeg-powered video capture invocation for Linux, adding `-ss {delay}` to support delaying capture of raw video from the webcam. 

This functionality is super handy if a webcam takes a second or two to initialize before returning frames. With no initial capture delay, GIFs like this can be recorded:

![dbb90b64ac0](https://user-images.githubusercontent.com/33840/90325827-7f099900-df4e-11ea-9045-7ed6099e9ccb.gif)

But a couple seconds of delay remediates that

![12818d83391](https://user-images.githubusercontent.com/33840/90325869-035c1c00-df4f-11ea-9d27-8aad33b846e5.gif)

[ffmpeg's `-ss`](https://trac.ffmpeg.org/wiki/Seeking) is used to seek to a particular time in the input. And it turns out it also achieves the effect of not capturing the specified seconds in the output video. 

---
#### :memo: Checklist

Please check this list and leave it intact for the reviewer. Thanks! :heart:

- [X] Commit messages provide context (why not just what, some tips [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).
- [X] If relevant, mention GitHub issue number above and include in a commit message.
- [X] Latest code from master merged.
- [ ] New behaviour has test coverage.
- [X] Avoid duplicating code.
- [X] No commented out code.
- [X] Avoid comments for your code, write code that explains itself.
- [X] Changes are simple, useful, clear and brief.
