### PR TITLE
Prep 0.16.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning][Semver].
 
   * Your contribution here!
 
+## [0.16.3][] (28 Jan 2021)
+  * Upgrade gem dependencies (for Ruby 3.0 compatibility)
+  * Fix failing RuboCops and update config
+  * Update Travis CI rubies
+
 ## [0.16.2][] (24 Aug 2020)
   * Support delays w/ Linux animated GIFs (@theY4Kman [#405][])
   * Upgrade git gem to version 1.6.0 (@depfu [#402][])
@@ -378,7 +383,8 @@ This project adheres to [Semantic Versioning][Semver].
   reliable to not glitch.)
 
 [Semver]: http://semver.org
-[Unreleased]: https://github.com/lolcommits/lolcommits/compare/v0.16.2...HEAD
+[Unreleased]: https://github.com/lolcommits/lolcommits/compare/v0.16.3...HEAD
+[0.16.3]: https://github.com/lolcommits/lolcommits/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/lolcommits/lolcommits/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/lolcommits/lolcommits/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/lolcommits/lolcommits/compare/v0.15.1...v0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning][Semver].
 
 ## [0.16.3][] (28 Jan 2021)
   * Upgrade gem dependencies (for Ruby 3.0 compatibility)
+  * Patched `mercurial-ruby` to work with Ruby 3.0 [#411][])
+  * Fixed up the formatting of generated hooks in `.hg/hgrc` [#411][])
   * Fix failing RuboCops and update config
   * Update Travis CI rubies
 
@@ -596,3 +598,4 @@ This project adheres to [Semantic Versioning][Semver].
 [#401]: https://github.com/lolcommits/lolcommits/pull/401
 [#402]: https://github.com/lolcommits/lolcommits/pull/402
 [#405]: https://github.com/lolcommits/lolcommits/pull/405
+[#411]: https://github.com/lolcommits/lolcommits/pull/411

--- a/lib/core_ext/mercurial-ruby/changed_file.rb
+++ b/lib/core_ext/mercurial-ruby/changed_file.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Mercurial
+  class ChangedFile
+    private
+
+    def enforce_unicode(str)
+      # String#encode patched to be Ruby 3.0+ compatible
+      str.encode('utf-8', invalid: :replace, undef: :replace, replace: '?')
+    end
+  end
+end

--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -9,7 +9,6 @@ require 'open3'
 require 'methadone'
 require 'date'
 require 'mercurial-ruby'
-require 'core_ext/mercurial-ruby/shell'
 
 require 'lolcommits/version'
 require 'lolcommits/configuration'
@@ -23,6 +22,10 @@ require 'lolcommits/plugin/base'
 
 # after lolcommits/platform, so that we can do platform-conditional override
 require 'core_ext/mercurial-ruby/command'
+require 'core_ext/mercurial-ruby/shell'
+
+# String#encode patched to be Ruby 3.0+ compatible
+require 'core_ext/mercurial-ruby/changed_file'
 
 # backends
 require 'lolcommits/backends/installation_git'

--- a/lib/lolcommits/backends/installation_mercurial.rb
+++ b/lib/lolcommits/backends/installation_mercurial.rb
@@ -49,11 +49,7 @@ module Lolcommits
         exports = "set path=\"%PATH%;#{ruby_path};#{imagick_path}\""
       end
 
-      <<-HOOK
-        ### lolcommits hook (begin) ###
-        #{exports} && #{capture_cmd}
-        ###  lolcommits hook (end)  ###
-      HOOK
+      "#{exports} && #{capture_cmd}"
     end
 
     def self.repository

--- a/lib/lolcommits/version.rb
+++ b/lib/lolcommits/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Lolcommits
-  VERSION  = '0.16.2'
-  GEM_NAME = 'lolcommits'
+  VERSION  = "0.16.3"
+  GEM_NAME = "lolcommits"
 end


### PR DESCRIPTION
Prepares gem for a new release 

* Includes gem updates from prior PRs (including git to ~> 1.8.1, Fixes #410)
* Patches mercurial-ruby (again) to work with Ruby 3.0. This gem is old and was using last args to `str.encode` as keyword parameters (which is now **not** supported in Ruby 3.0 and was deprecated in 2.7)
* Also fixed up the formatting and spacing of generated lolcommit hooks in mercurial's `.hg/hgrc` file