### PR TITLE
Update minimum Ruby to 3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tmp
 *.swo
 vendor/bundle
 cc-test-reporter
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ This project adheres to [Semantic Versioning][Semver].
 
 ## [Unreleased]
 
-  * Your contribution here!
+  * Update minimum Ruby version to 3.1 (oldest supported version)
+  * Patch `mercurial-ruby` to work with Ruby 3.2
+  * Update `optparse-plus` gem from 1.x to 3.x
+  * Update `mini_magick` gem from 4.x to 5.x
+  * Update `launchy` gem from 2.x to 3.x
+  * Update `git` gem from 1.x to 2.x
 
 ## [0.16.5][] (29 May 2024)
   * Use Git 1.19.1 [#430][]

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -8,14 +8,14 @@ rescue LoadError
 end
 
 require 'optparse'
-require 'methadone'
+require 'optparse_plus'
 require 'lolcommits/cli.rb'
 
 # allow logging from everywhere
-include Methadone::CLILogging
+include OptparsePlus::CLILogging
 
 class App
-  include Methadone::Main
+  include OptparsePlus::Main
 
   include Lolcommits
   include Lolcommits::CLI

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'aruba/cucumber'
-require 'methadone/cucumber'
+require 'optparse_plus/cucumber'
 require 'open3'
 require 'ffaker'
 require 'fileutils'

--- a/lib/core_ext/mercurial-ruby/config_file.rb
+++ b/lib/core_ext/mercurial-ruby/config_file.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Mercurial
+  class ConfigFile
+    def exists?
+      # Mercurial::ConfigFile#exists? patched to be Ruby 3.2+ compatible
+      File.exist?(path)
+    end
+  end
+end

--- a/lib/core_ext/mercurial-ruby/repository.rb
+++ b/lib/core_ext/mercurial-ruby/repository.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Mercurial
+  class Repository
+    def self.open(destination)
+      # Mercurial::Repository.open patched to be Ruby 3.2+ compatible
+      raise Mercurial::RepositoryNotFound, destination unless File.exist?(destination)
+
+      new(destination)
+    end
+  end
+end

--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -6,7 +6,7 @@ require 'mini_magick'
 require 'fileutils'
 require 'git'
 require 'open3'
-require 'methadone'
+require 'optparse_plus'
 require 'date'
 require 'mercurial-ruby'
 
@@ -26,6 +26,10 @@ require 'core_ext/mercurial-ruby/shell'
 
 # String#encode patched to be Ruby 3.0+ compatible
 require 'core_ext/mercurial-ruby/changed_file'
+# Mercurial::ConfigFile#exists? patched to be Ruby 3.2+ compatible
+require 'core_ext/mercurial-ruby/config_file'
+# Mercurial::Repository.open patched to be Ruby 3.2+ compatible
+require 'core_ext/mercurial-ruby/repository'
 
 # backends
 require 'lolcommits/backends/installation_git'

--- a/lib/lolcommits/backends/git_info.rb
+++ b/lib/lolcommits/backends/git_info.rb
@@ -2,7 +2,7 @@
 
 module Lolcommits
   class GitInfo
-    GIT_URL_REGEX = %r{.*:([/\w-]*).git}.freeze
+    GIT_URL_REGEX = %r{.*:([/\w-]*).git}
 
     def self.repo_root?(path = '.')
       File.directory?(File.join(path, '.git'))

--- a/lib/lolcommits/cli/fatals.rb
+++ b/lib/lolcommits/cli/fatals.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'lolcommits/platform'
-require 'methadone'
+require 'optparse_plus'
 
 module Lolcommits
   module CLI

--- a/lib/lolcommits/cli/timelapse_gif.rb
+++ b/lib/lolcommits/cli/timelapse_gif.rb
@@ -31,8 +31,12 @@ module Lolcommits
 
         puts '*** Generating animated timelapse gif.'
 
-        gif = MiniMagick::Image.new(File.join(timelapses_dir_path, "#{filename}.gif"))
-        gif.run_command('convert', *['-delay', '50', '-loop', '0', lolimages, gif.path].flatten)
+        MiniMagick.convert do |convert|
+          convert.delay 50
+          convert.loop 0
+          lolimages.each { |image| convert << image }
+          convert << File.join(timelapses_dir_path, "#{filename}.gif")
+        end
 
         puts "*** Done, generated at #{gif.path}"
       end

--- a/lib/lolcommits/plugin_manager.rb
+++ b/lib/lolcommits/plugin_manager.rb
@@ -2,7 +2,7 @@
 
 module Lolcommits
   class PluginManager
-    GEM_NAME_PREFIX = /^#{Lolcommits::GEM_NAME}-/.freeze
+    GEM_NAME_PREFIX = /^#{Lolcommits::GEM_NAME}-/
 
     def self.init
       pm = new

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -33,17 +33,17 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # non-gem dependencies
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 3.1'
   s.requirements << 'imagemagick'
   s.requirements << 'a webcam'
 
   # core
-  s.add_runtime_dependency('methadone', '~> 1.9.5')
+  s.add_runtime_dependency('optparse-plus', '~> 3.0')
   s.add_runtime_dependency('mercurial-ruby', '~> 0.7.12')
-  s.add_runtime_dependency('mini_magick', '~> 4.12.0')
-  s.add_runtime_dependency('launchy', '~> 2.5.0')
+  s.add_runtime_dependency('mini_magick', '~> 5.0.1')
+  s.add_runtime_dependency('launchy', '~> 3.0.1')
   s.add_runtime_dependency('open4', '~> 1.3.4')
-  s.add_runtime_dependency('git', '~> 1.19.1')
+  s.add_runtime_dependency('git', '~> 2.1.1')
 
   # included plugins
   s.add_runtime_dependency('lolcommits-loltext', '~> 0.4.0')


### PR DESCRIPTION
Update the dependencies to the latest versions.

Ruby 3.2 dropped support for `File.exists?` and only has the singular `File.exist?`.

---
#### :memo: Checklist

- [x] Commit messages provide context (why not just what, some tips [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).
- [ ] If relevant, mention GitHub issue number above and include in a commit message.
- [x] Latest code from master merged.
- [x] New behaviour has test coverage.
- [x] Avoid duplicating code.
- [x] No commented out code.
- [x] Avoid comments for your code, write code that explains itself.
- [x] Changes are simple, useful, clear and brief.
